### PR TITLE
Workaround for known issue in 'assetic:dump'

### DIFF
--- a/Docker/docker-entrypoint.sh
+++ b/Docker/docker-entrypoint.sh
@@ -25,7 +25,7 @@ cd /app/app
 php console cache:clear --env=prod
 php console cache:warmup --env=prod
 chown -R www-data:www-data /app/app/cache && find /app/app/cache -type d -exec chmod -R 0770 {} \; && find /app/app/cache -type f -exec chmod -R 0660 {} \;
-php console assetic:dump --env=prod
+php console assetic:dump --env=prod || /bin/true
 
 nginx
 php-fpm -F


### PR DESCRIPTION
Implement workaround for issue causing container not to start properly:
```
March 30th 2020, 12:11:33.842 assetic:dump [--forks FORKS] [--watch] [--force] [--period PERIOD] [--] [<write_to>]
March 30th 2020, 12:11:33.835  There is no "less" filter.  
March 30th 2020, 12:11:33.835  [InvalidArgumentException]
```